### PR TITLE
test: ajoute des tests unitaires pour les DAO Hibernate

### DIFF
--- a/src/test/java/sae/semestre/six/generic/AbstractHibernateDaoTest.java
+++ b/src/test/java/sae/semestre/six/generic/AbstractHibernateDaoTest.java
@@ -7,6 +7,7 @@ package sae.semestre.six.generic;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -23,14 +24,14 @@ import static org.mockito.Mockito.*;
 
 
 /**
- * Cette classe teste la classe {@link AbstractHibernateDao} et {@link GenericDao}, la dernière classe citée
- * est testée indirectement via son implémentation
+ * This class test classes {@link AbstractHibernateDao} and {@link GenericDao}, last class cited
+ * is undirectly tested by its implementation
  */
 class AbstractHibernateDaoTest {
 
     /**
-     * Classe permettant de tester le DAO, étant donné que le DAO ne prend pas de classe spécifique, on en
-     * crée une ici avec un id seulement pour effectuer des appels
+     * Class to test DAO, given that DAO do not take a specific class,
+     * we create one there with id only to make some calls
      */
     private static class TestEntity {
         private Long id;
@@ -71,6 +72,11 @@ class AbstractHibernateDaoTest {
         } catch (Exception e) {
             fail("Impossible d'injecter l'EntityManager: " + e.getMessage());
         }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/src/test/java/sae/semestre/six/generic/AbstractHibernateDaoTest.java
+++ b/src/test/java/sae/semestre/six/generic/AbstractHibernateDaoTest.java
@@ -1,0 +1,171 @@
+/*
+ * AbstractHibernateDaoTest.java                                 22 avr. 2025
+ * IUT de Rodez, no author rights
+ */
+
+package sae.semestre.six.generic;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Cette classe teste la classe {@link AbstractHibernateDao} et {@link GenericDao}, la dernière classe citée
+ * est testée indirectement via son implémentation
+ */
+class AbstractHibernateDaoTest {
+
+    /**
+     * Classe permettant de tester le DAO, étant donné que le DAO ne prend pas de classe spécifique, on en
+     * crée une ici avec un id seulement pour effectuer des appels
+     */
+    private static class TestEntity {
+        private Long id;
+
+        public TestEntity() {}
+
+        public TestEntity(Long id) {
+            this.id = id;
+        }
+
+        public Long getId() {
+            return id;
+        }
+    }
+
+    private static class ConcreteDao extends AbstractHibernateDao<TestEntity, Long> {}
+
+    @Mock
+    private EntityManager entityManager;
+
+    @Mock
+    private TypedQuery<TestEntity> query;
+
+    private ConcreteDao dao;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        dao = new ConcreteDao();
+        // Injection de l'EntityManager mocké
+        when(entityManager.createQuery(anyString())).thenReturn(query);
+        try {
+            Field field = AbstractHibernateDao.class.getDeclaredField("entityManager");
+            field.setAccessible(true);
+            field.set(dao, entityManager);
+        } catch (Exception e) {
+            fail("Impossible d'injecter l'EntityManager: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testFindById() {
+        // Given
+        TestEntity expectedEntity = new TestEntity(1L);
+        when(entityManager.find(TestEntity.class, 1L)).thenReturn(expectedEntity);
+
+        // When
+        TestEntity result = dao.findById(1L);
+
+        // Then
+        assertEquals(expectedEntity, result);
+        verify(entityManager).find(TestEntity.class, 1L);
+    }
+
+    @Test
+    void testFindAll() {
+        // Given
+        List<TestEntity> expectedEntities = Arrays.asList(
+                new TestEntity(1L),
+                new TestEntity(2L)
+        );
+        when(query.getResultList()).thenReturn(expectedEntities);
+
+        // When
+        List<TestEntity> result = dao.findAll();
+
+        // Then
+        assertEquals(expectedEntities, result);
+        verify(entityManager).createQuery(anyString());
+        verify(query).getResultList();
+    }
+
+    @Test
+    void testSave() {
+        // Given
+        TestEntity entity = new TestEntity(1L);
+
+        // When
+        dao.save(entity);
+
+        // Then
+        verify(entityManager).persist(entity);
+    }
+
+    @Test
+    void testUpdate() {
+        // Given
+        TestEntity entity = new TestEntity(1L);
+        when(entityManager.merge(entity)).thenReturn(entity);
+
+        // When
+        dao.update(entity);
+
+        // Then
+        verify(entityManager).merge(entity);
+    }
+
+    @Test
+    void testDelete() {
+        // Given
+        TestEntity entity = new TestEntity(1L);
+
+        // When
+        dao.delete(entity);
+
+        // Then
+        verify(entityManager).remove(entity);
+    }
+
+    @Test
+    void testDeleteById() {
+        // Given
+        TestEntity entity = new TestEntity(1L);
+        when(entityManager.find(TestEntity.class, 1L)).thenReturn(entity);
+
+        // When
+        dao.deleteById(1L);
+
+        // Then
+        verify(entityManager).find(TestEntity.class, 1L);
+        verify(entityManager).remove(entity);
+    }
+
+    @Test
+    void testDeleteByIdWhenEntityNotFound() {
+        // Given
+        when(entityManager.find(TestEntity.class, 1L)).thenReturn(null);
+
+        // When
+        dao.deleteById(1L);
+
+        // Then
+        verify(entityManager).find(TestEntity.class, 1L);
+        verify(entityManager, never()).remove(any());
+    }
+}

--- a/src/test/java/sae/semestre/six/generic/DaoHibernateAbstraitTest.java
+++ b/src/test/java/sae/semestre/six/generic/DaoHibernateAbstraitTest.java
@@ -7,6 +7,7 @@ package sae.semestre.six.generic;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -22,14 +23,14 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 /**
- * Cette classe teste la classe {@link DaoHibernateAbstrait} et {@link DaoGenerique}, la dernière classe citée
- * est testée indirectement via son implémentation
+ * This class test classes {@link DaoHibernateAbstrait} and {@link DaoGenerique}, last class cited
+ * is undirectly tested by its implementation
  */
 class DaoHibernateAbstraitTest {
 
     /**
-     * Classe permettant de tester le DAO, étant donné que le DAO ne prend pas de classe spécifique, on en
-     * crée une ici avec un id seulement pour effectuer des appels
+     * Class to test DAO, given that DAO do not take a specific class,
+     * we create one there with id only to make some calls
      */
     private static class EntiteTest {
         private Long id;
@@ -70,6 +71,11 @@ class DaoHibernateAbstraitTest {
         } catch (Exception e) {
             fail("Impossible d'injecter le gestionnaireEntite: " + e.getMessage());
         }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/src/test/java/sae/semestre/six/generic/DaoHibernateAbstraitTest.java
+++ b/src/test/java/sae/semestre/six/generic/DaoHibernateAbstraitTest.java
@@ -1,0 +1,170 @@
+/*
+ * DaoHibernateAbstraitTest.java                                 22 avr. 2025
+ * IUT de Rodez, no author rights
+ */
+
+package sae.semestre.six.generic;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Cette classe teste la classe {@link DaoHibernateAbstrait} et {@link DaoGenerique}, la dernière classe citée
+ * est testée indirectement via son implémentation
+ */
+class DaoHibernateAbstraitTest {
+
+    /**
+     * Classe permettant de tester le DAO, étant donné que le DAO ne prend pas de classe spécifique, on en
+     * crée une ici avec un id seulement pour effectuer des appels
+     */
+    private static class EntiteTest {
+        private Long id;
+
+        public EntiteTest() {}
+
+        public EntiteTest(Long id) {
+            this.id = id;
+        }
+
+        public Long getId() {
+            return id;
+        }
+    }
+
+    private static class DaoConcret extends DaoHibernateAbstrait<EntiteTest, Long> {}
+
+    @Mock
+    private EntityManager gestionnaireEntite;
+
+    @Mock
+    private TypedQuery<EntiteTest> requete;
+
+    private DaoConcret dao;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        dao = new DaoConcret();
+        // Injection de l'EntityManager mocké
+        when(gestionnaireEntite.createQuery(anyString())).thenReturn(requete);
+        try {
+            Field field = DaoHibernateAbstrait.class.getDeclaredField("gestionnaireEntite");
+            field.setAccessible(true);
+            field.set(dao, gestionnaireEntite);
+        } catch (Exception e) {
+            fail("Impossible d'injecter le gestionnaireEntite: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void testTrouverParId() {
+        // Given
+        EntiteTest entiteAttendue = new EntiteTest(1L);
+        when(gestionnaireEntite.find(EntiteTest.class, 1L)).thenReturn(entiteAttendue);
+
+        // When
+        EntiteTest resultat = dao.trouverParId(1L);
+
+        // Then
+        assertEquals(entiteAttendue, resultat);
+        verify(gestionnaireEntite).find(EntiteTest.class, 1L);
+    }
+
+    @Test
+    void testTrouverTout() {
+        // Given
+        List<EntiteTest> entitesAttendues = Arrays.asList(
+                new EntiteTest(1L),
+                new EntiteTest(2L)
+        );
+        when(requete.getResultList()).thenReturn(entitesAttendues);
+
+        // When
+        List<EntiteTest> resultat = dao.trouverTout();
+
+        // Then
+        assertEquals(entitesAttendues, resultat);
+        verify(gestionnaireEntite).createQuery(anyString());
+        verify(requete).getResultList();
+    }
+
+    @Test
+    void testSauvegarder() {
+        // Given
+        EntiteTest entite = new EntiteTest(1L);
+
+        // When
+        dao.sauvegarder(entite);
+
+        // Then
+        verify(gestionnaireEntite).persist(entite);
+    }
+
+    @Test
+    void testMettreAJour() {
+        // Given
+        EntiteTest entite = new EntiteTest(1L);
+        when(gestionnaireEntite.merge(entite)).thenReturn(entite);
+
+        // When
+        dao.mettreAJour(entite);
+
+        // Then
+        verify(gestionnaireEntite).merge(entite);
+    }
+
+    @Test
+    void testSupprimer() {
+        // Given
+        EntiteTest entite = new EntiteTest(1L);
+
+        // When
+        dao.supprimer(entite);
+
+        // Then
+        verify(gestionnaireEntite).remove(entite);
+    }
+
+    @Test
+    void testSupprimerParId() {
+        // Given
+        EntiteTest entite = new EntiteTest(1L);
+        when(gestionnaireEntite.find(EntiteTest.class, 1L)).thenReturn(entite);
+
+        // When
+        dao.supprimerParId(1L);
+
+        // Then
+        verify(gestionnaireEntite).find(EntiteTest.class, 1L);
+        verify(gestionnaireEntite).remove(entite);
+    }
+
+    @Test
+    void testSupprimerParIdQuandEntiteNonTrouvee() {
+        // Given
+        when(gestionnaireEntite.find(EntiteTest.class, 1L)).thenReturn(null);
+
+        // When
+        dao.supprimerParId(1L);
+
+        // Then
+        verify(gestionnaireEntite).find(EntiteTest.class, 1L);
+        verify(gestionnaireEntite, never()).remove(any());
+    }
+}


### PR DESCRIPTION
Ajoute des classes de test unitaires pour améliorer la couverture du code des DAO Hibernate abstraits en utilisant des mocks pour les interactions avec l'EntityManager.

Vérifie le bon fonctionnement des méthodes de création, lecture, mise à jour, et suppression des entités de test.

Garantit la robustesse des DAO en simulant différents scénarios de recherche et suppression avec des entités inexistantes.