### PR TITLE
Test/appointment/prescription

### DIFF
--- a/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionControllerInegrationTest.java
+++ b/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionControllerInegrationTest.java
@@ -9,7 +9,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -18,10 +17,8 @@ import sae.semestre.six.appointment.patient.Patient;
 import sae.semestre.six.appointment.patient.PatientDao;
 
 import java.util.Date;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionControllerInegrationTest.java
+++ b/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionControllerInegrationTest.java
@@ -1,0 +1,127 @@
+package sae.semestre.six.appointment.prescription;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import sae.semestre.six.appointment.bill.BillingService;
+import sae.semestre.six.appointment.patient.Patient;
+import sae.semestre.six.appointment.patient.PatientDao;
+
+import java.util.Date;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(PrescriptionController.class)
+class PrescriptionControllerInegrationTest {
+
+    private MockMvc server;
+
+    @InjectMocks
+    private PrescriptionController prescriptionController;
+
+    @MockitoBean
+    private BillingService billingService;
+    @MockitoBean
+    private PatientDao patientDao;
+    @MockitoBean
+    private PrescriptionDao prescriptionDao;
+
+    private AutoCloseable autoCloseable;
+
+    @BeforeEach
+    void setUp() {
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        server = MockMvcBuilders.standaloneSetup(prescriptionController).build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        autoCloseable.close();
+    }
+
+    private Patient createTestPatient() {
+        Patient patient = new Patient();
+        patient.setId(1L);
+        patient.setFirstName("John");
+        patient.setLastName("Doe");
+        patient.setPatientNumber("P12345");
+        patient.setPhoneNumber("1234567890");
+        patient.setGender("Male");
+        patient.setDateOfBirth(new Date());
+        patient.setAddress("123 Main St");
+        return patient;
+    }
+
+    @Test
+    void addPrescription() throws Exception {
+        int counter = 1;
+        Patient patient = createTestPatient();
+        String[] medicines = {"PARACETAMOL", "ANTIBIOTICS"};
+        String notes = "Take with food";
+
+        when(patientDao.findById(1L)).thenReturn(patient);
+
+        server.perform(post("/prescriptions/add")
+                        .param("patientId", patient.getId().toString())
+                        .param("medicines", medicines)
+                        .param("notes", notes))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("Prescription RX" + counter + " created and billed"));
+
+        verify(patientDao).findById(patient.getId());
+        verify(prescriptionDao).save(any(Prescription.class));
+        verify(billingService).processBill(
+                patient.getId().toString(),
+                "SYSTEM",
+                new String[]{"PRESCRIPTION_RX" + counter}
+        );
+    }
+
+    @Test
+    void addPrescriptionButPatientAbsent() throws Exception {
+        Long nonExistentPatientId = 9999L;
+        String[] medicines = {"PARACETAMOL", "ANTIBIOTICS"};
+        String notes = "Take with food";
+
+        when(patientDao.findById(nonExistentPatientId)).thenThrow(new RuntimeException("Patient not found"));
+
+        server.perform(post("/prescriptions/add")
+                        .param("patientId", String.valueOf(nonExistentPatientId))
+                        .param("medicines", medicines)
+                        .param("notes", notes))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string(containsString("Failed")));
+    }
+
+    @Test
+    void getPatientPrescriptions() throws Exception {
+        // Arrange
+        String patientId = "1";
+        Patient patient = createTestPatient();
+        when(patientDao.findById(Long.parseLong(patientId))).thenReturn(patient);
+
+        // Act
+        server.perform(get("/prescriptions/patient/" + patientId))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("[]")); // Assuming no prescriptions exist
+    }
+}

--- a/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionDaoImplTest.java
+++ b/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionDaoImplTest.java
@@ -1,0 +1,70 @@
+package sae.semestre.six.appointment.prescription;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import sae.semestre.six.appointment.patient.Patient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+public class PrescriptionDaoImplTest {
+
+    @Autowired
+    private PrescriptionDaoImpl prescriptionDao;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void testFindByPatientId_ReturnsPrescriptions_WhenPatientExists() {
+        Patient patient = new Patient();
+        patient.setPatientNumber("PAT001");
+        patient.setFirstName("John");
+        patient.setLastName("Doe");
+        
+        entityManager.persist(patient);
+        
+        Prescription prescription = new Prescription();
+        prescription.setPrescriptionNumber("RX123");
+        prescription.setPatient(patient);
+        entityManager.persist(prescription);
+        entityManager.flush();
+
+        Long patientId = patient.getId();
+        List<Prescription> prescriptions = prescriptionDao.findByPatientId(patientId);
+
+        assertEquals(1, prescriptions.size());
+        assertEquals("RX123", prescriptions.get(0).getPrescriptionNumber());
+    }
+
+    @Test
+    void testFindByPatientId_ReturnsEmptyList_WhenPatientHasNoPrescriptions() {
+        Long patientId = 2L;
+
+        List<Prescription> prescriptions = prescriptionDao.findByPatientId(patientId);
+
+        assertEquals(0, prescriptions.size());
+        assertTrue(prescriptions.isEmpty());
+    }
+
+    @Test
+    void testFindByPatientId_ReturnsEmptyList_WhenPatientDoesNotExist() {
+        Long patientId = 99L;
+
+        List<Prescription> prescriptions = prescriptionDao.findByPatientId(patientId);
+
+        assertEquals(0, prescriptions.size());
+        assertTrue(prescriptions.isEmpty());
+    }
+}

--- a/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionDaoImplTest.java
+++ b/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionDaoImplTest.java
@@ -4,21 +4,18 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 import sae.semestre.six.appointment.patient.Patient;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-public class PrescriptionDaoImplTest {
+class PrescriptionDaoImplTest {
 
     @Autowired
     private PrescriptionDaoImpl prescriptionDao;
@@ -32,7 +29,7 @@ public class PrescriptionDaoImplTest {
         patient.setPatientNumber("PAT001");
         patient.setFirstName("John");
         patient.setLastName("Doe");
-        
+
         entityManager.persist(patient);
 
         Prescription prescription = new Prescription();

--- a/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionDaoImplTest.java
+++ b/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionDaoImplTest.java
@@ -34,7 +34,7 @@ public class PrescriptionDaoImplTest {
         patient.setLastName("Doe");
         
         entityManager.persist(patient);
-        
+
         Prescription prescription = new Prescription();
         prescription.setPrescriptionNumber("RX123");
         prescription.setPatient(patient);

--- a/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionTest.java
+++ b/src/test/java/sae/semestre/six/appointment/prescription/PrescriptionTest.java
@@ -1,0 +1,65 @@
+package sae.semestre.six.appointment.prescription;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PrescriptionTest {
+
+    @Test
+    void testSetBilledSetsBilledStatusToTrue() {
+        // Arrange
+        Prescription prescription = new Prescription();
+        Boolean initialBilledStatus = prescription.getBilled();
+
+        // Act
+        prescription.setBilled(true);
+
+        // Assert
+        assertFalse(initialBilledStatus, "Initial billed status should be false");
+        assertTrue(prescription.getBilled(), "Billed status should be true after setting it to true");
+        assertNotNull(prescription.getLastModified(), "LastModified date should not be null");
+    }
+
+    @Test
+    void testSetBilledSetsBilledStatusToFalse() {
+        // Arrange
+        Prescription prescription = new Prescription();
+        prescription.setBilled(true); // Set to true to verify toggle back to false
+        Date lastModifiedBefore = prescription.getLastModified();
+
+        // Simulate some time passing
+        await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            // Act
+            prescription.setBilled(false);
+            return true;
+        });
+
+
+        // Assert
+        assertFalse(prescription.getBilled(), "Billed status should be false after setting it to false");
+        assertNotEquals(lastModifiedBefore, prescription.getLastModified(), "LastModified date should be updated");
+    }
+
+    @Test
+    void testSetBilledUpdatesLastModifiedDate() {
+        // Arrange
+        Prescription prescription = new Prescription();
+        Date initialLastModified = prescription.getLastModified();
+
+        // Simulate some time passing
+        await().atMost(200, TimeUnit.MILLISECONDS).until(() -> {
+            // Act
+            prescription.setBilled(false);
+            return true;
+        });
+
+        // Assert
+        assertNotNull(prescription.getLastModified(), "LastModified date should not be null");
+        assertNotEquals(initialLastModified, prescription.getLastModified(), "LastModified date should be updated");
+    }
+}


### PR DESCRIPTION
This pull request introduces comprehensive test coverage for the `Prescription` module, including integration tests for the `PrescriptionController`, DAO tests for `PrescriptionDaoImpl`, and unit tests for the `Prescription` entity. These changes aim to ensure robust functionality and proper behavior of the prescription-related features.

### Integration Tests for `PrescriptionController`:
* Added `PrescriptionControllerIntegrationTest` to verify the behavior of adding prescriptions, handling absent patients, and fetching patient prescriptions. This includes mocking dependencies like `BillingService` and `PrescriptionDao` and using `MockMvc` for HTTP request simulations.

### DAO Tests for `PrescriptionDaoImpl`:
* Added `PrescriptionDaoImplTest` to validate the `findByPatientId` method. Tests include scenarios where a patient has prescriptions, has none, or does not exist in the database. These tests use an in-memory database with `EntityManager` for persistence.

### Unit Tests for `Prescription` Entity:
* Added `PrescriptionTest` to verify the behavior of the `setBilled` method, ensuring it updates the billed status and modifies the `lastModified` timestamp correctly. Tests include toggling the billed status and checking the timestamp updates.