### PR TITLE
change H2 to mysql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,28 @@ jobs: # Definition of the workflow jobs
           restore-keys: |
             ${{ runner.os }}-gradle- # Fallback key to restore a partial cache
 
+      - name: Start MySQL container
+        run: docker compose -f docker/docker-compose.test.yml up -d
+
+      - name: Wait for MySQL to be ready
+        run: |
+          timeout 60s bash -c 'until docker exec mysql-test mysqladmin ping -h localhost -u root -ptest --silent; do sleep 2; done'
+
       - name: Grant execution permissions to Gradle Wrapper
         run: chmod +x ./gradlew # Allow execution of the gradlew script (required on Linux)
 
       - name: Build and test the project
         run: ./gradlew build --no-daemon # Build and run all tests
+        env:
+          MYSQL_HOST: localhost
+          MYSQL_PORT: 3307
+          MYSQL_DATABASE: hospital_test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
 
       - name: Check code quality
         run: ./gradlew check --no-daemon # Run code quality checks (Linting, static analysis...)
+
+      - name: Stop MySQL container
+        if: always()
+        run: docker compose -f docker/docker-compose.test.yml down

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -47,6 +47,13 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Start MySQL container
+        run: docker compose -f docker/docker-compose.test.yml up -d
+
+      - name: Wait for MySQL to be ready
+        run: |
+          timeout 60s bash -c 'until docker exec mysql-test mysqladmin ping -h localhost -u root -ptest --silent; do sleep 2; done'
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
@@ -54,3 +61,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew build sonar --info
+
+      - name: Stop MySQL container
+        if: always()
+        run: docker compose -f docker/docker-compose.test.yml down

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.4'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'com.h2database:h2:2.2.224'
     testImplementation 'org.mockito:mockito-core:5.10.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.10.0'
     testImplementation 'com.icegreen:greenmail-junit5:2.0.0'

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,16 @@
+services:
+  mysql-test:
+    image: mysql:8.0.42
+    container_name: mysql-test
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: hospital_test
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-ptest"]
+      interval: 5s
+      timeout: 5s
+      retries: 5 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,29 +1,21 @@
 # Test-specific configuration
 server.port=8081
-# H2 Database Configuration
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
 
-# JPA/Hibernate configuration
-# Enable automatic schema creation
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+# Test Database Configuration
+spring.datasource.url=jdbc:mysql://localhost:3307/hospital_test?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.username=test
+spring.datasource.password=test
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
-# Enable H2 console (optional, useful for debugging)
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+# Disable open-in-view to prevent warning in tests
+spring.jpa.open-in-view=false
 
-# Mail
+# Disable mail sending in tests
 spring.mail.host=localhost
-spring.mail.port=1025
-spring.mail.username=
-spring.mail.password=
+spring.mail.port=3025
+spring.mail.username=test
+spring.mail.password=test
 spring.mail.properties.mail.smtp.auth=false
-spring.mail.properties.mail.smtp.starttls.enable=false
-spring.mail.properties.mail.smtp.connectiontimeout=5000
-spring.mail.properties.mail.smtp.timeout=3000
-spring.mail.properties.mail.smtp.writetimeout=5000
+spring.mail.properties.mail.smtp.starttls.enable=false 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -12,10 +12,13 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 # Disable open-in-view to prevent warning in tests
 spring.jpa.open-in-view=false
 
-# Disable mail sending in tests
+# Mail
 spring.mail.host=localhost
-spring.mail.port=3025
-spring.mail.username=test
-spring.mail.password=test
+spring.mail.port=1025
+spring.mail.username=
+spring.mail.password=
 spring.mail.properties.mail.smtp.auth=false
-spring.mail.properties.mail.smtp.starttls.enable=false 
+spring.mail.properties.mail.smtp.starttls.enable=false
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=3000
+spring.mail.properties.mail.smtp.writetimeout=5000


### PR DESCRIPTION
Close #62 
This pull request introduces changes to migrate the test environment from an in-memory H2 database to a MySQL containerized database for improved test reliability and closer alignment with production. Key updates include modifications to the CI workflow, the addition of a Docker Compose file, and updates to the test configuration properties.

### CI Workflow Updates:
* Added steps in `.github/workflows/ci.yml` to start and stop a MySQL container during CI runs, including a health check to ensure the database is ready before tests execute. Environment variables for MySQL connection details were also added to the build step.

### Docker Configuration:
* Introduced `docker/docker-compose.test.yml` to define a MySQL 8.0.42 service for testing, with appropriate environment variables, port mapping, and a health check for readiness.

### Test Configuration Updates:
* Replaced H2 database configuration in `src/test/resources/application.properties` with MySQL connection details, updated the Hibernate dialect to `MySQLDialect`, and disabled `spring.jpa.open-in-view` to avoid warnings during tests. Additionally, mail configuration was adjusted for the test environment.